### PR TITLE
Messing with the ADIF name dictionary creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>uk.m0nom</groupId>
     <artifactId>adifweb</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.25</version>
     <name>adifweb</name>
     <url>https://github.com/urbancamo/adifweb</url>
     <description>Web Interface for the ADIF Transformer</description>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>uk.m0nom</groupId>
             <artifactId>adif-processor</artifactId>
-            <version>1.0.24</version>
+            <version>1.0.25</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload -->
         <dependency>


### PR DESCRIPTION
Update the AdiWriter so that it doesnt output :E in the header of code fields - this upsets the LOTW ADI importer